### PR TITLE
full implementation to write delegated application

### DIFF
--- a/src/main/java/org/esupportail/nfctag/beans/DesfireFlowStep.java
+++ b/src/main/java/org/esupportail/nfctag/beans/DesfireFlowStep.java
@@ -36,6 +36,8 @@ public class DesfireFlowStep implements Serializable {
 	public int damKeysStep = 0;
 
 	public int resetStep = 0;
+
+	public int createDamStep = 0;
 	 
 	public Action action;
 	

--- a/src/main/java/org/esupportail/nfctag/service/api/TagWriteApi.java
+++ b/src/main/java/org/esupportail/nfctag/service/api/TagWriteApi.java
@@ -18,6 +18,12 @@
 package org.esupportail.nfctag.service.api;
 
 import org.esupportail.nfctag.exceptions.EsupNfcTagException;
+import org.esupportail.nfctag.web.wsrest.json.JsonDamAuthKey;
+import org.esupportail.nfctag.web.wsrest.json.JsonFormCryptogram;
+import org.esupportail.nfctag.web.wsrest.json.JsonResponseCryptogram;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
 
 public interface TagWriteApi {
 
@@ -28,5 +34,9 @@ public interface TagWriteApi {
 	String getDiversDamKey(String csn) throws EsupNfcTagException;
 
 	String resetDiversDamKey(String csn) throws EsupNfcTagException;
+
+	JsonDamAuthKey getDamAuthKey(String csn) throws EsupNfcTagException;
+
+	JsonResponseCryptogram getCryptogram(JsonFormCryptogram jsonFormCryptogram) throws EsupNfcTagException;
 
 }

--- a/src/main/java/org/esupportail/nfctag/service/api/impl/DesfireDamUpdateConfig.java
+++ b/src/main/java/org/esupportail/nfctag/service/api/impl/DesfireDamUpdateConfig.java
@@ -1,0 +1,16 @@
+package org.esupportail.nfctag.service.api.impl;
+
+import org.esupportail.nfctag.service.TagAuthService;
+import org.esupportail.nfctag.service.desfire.DesfireService;
+import org.esupportail.nfctag.service.desfire.actions.DesfireActionService;
+import org.esupportail.nfctag.service.desfire.actions.DesfireDamUpdateActionService;
+import org.esupportail.nfctag.web.live.LiveLongPoolController;
+
+public class DesfireDamUpdateConfig extends DesfireWriteConfig {
+
+    @Override
+    public DesfireActionService getDesfireActionService(DesfireService desfireService, TagAuthService tagAuthService, LiveLongPoolController liveController) {
+        return new DesfireDamUpdateActionService(null, desfireService, tagAuthService, liveController);
+    }
+
+}

--- a/src/main/java/org/esupportail/nfctag/service/api/impl/TagWriteNone.java
+++ b/src/main/java/org/esupportail/nfctag/service/api/impl/TagWriteNone.java
@@ -21,7 +21,13 @@ import javax.annotation.Resource;
 
 import org.esupportail.nfctag.exceptions.EsupNfcTagException;
 import org.esupportail.nfctag.service.api.TagWriteApi;
+import org.esupportail.nfctag.web.wsrest.json.JsonDamAuthKey;
+import org.esupportail.nfctag.web.wsrest.json.JsonFormCryptogram;
+import org.esupportail.nfctag.web.wsrest.json.JsonResponseCryptogram;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
 
 public class TagWriteNone implements TagWriteApi {
 	
@@ -52,6 +58,16 @@ public class TagWriteNone implements TagWriteApi {
 	@Override
 	public String resetDiversDamKey(String csn) throws EsupNfcTagException {
 		return "00";
+	}
+
+	@Override
+	public JsonDamAuthKey getDamAuthKey(String csn) throws EsupNfcTagException {
+		return null;
+	}
+
+	@Override
+	public JsonResponseCryptogram getCryptogram(JsonFormCryptogram jsonFormCryptogram) throws EsupNfcTagException {
+		return null;
 	}
 
 }

--- a/src/main/java/org/esupportail/nfctag/service/desfire/DesfireDiversificationDamService.java
+++ b/src/main/java/org/esupportail/nfctag/service/desfire/DesfireDiversificationDamService.java
@@ -76,20 +76,19 @@ public class DesfireDiversificationDamService implements InitializingBean {
         System.arraycopy(appDAMDefault, 0, input, 7, 16);
         input[input.length - 1] = keyVerAppDAMDefault;
 
-        System.out.println("ENCK in " + DesfireUtils.byteArrayToHexString(input));
-        System.out.println("ENCK in " + DesfireUtils.byteArrayToHexString(piccDamEncKey));
-        System.out.println("ENCK in " + DesfireUtils.byteArrayToHexString(IV));
+        log.info("ENCK in " + DesfireUtils.byteArrayToHexString(input));
+        log.info("ENCK in " + DesfireUtils.byteArrayToHexString(piccDamEncKey));
+        log.info("ENCK in " + DesfireUtils.byteArrayToHexString(IV));
 
         byte[] EncK = desfireDiversification.encrypt(piccDamEncKey, input, IV);
 
-        System.out.println("ENCK  out" + DesfireUtils.byteArrayToHexString(EncK));
+        log.info("ENCK  out" + DesfireUtils.byteArrayToHexString(EncK));
 
         return EncK;
     }
 
     public byte[] calcDAMMAC(byte[] piccDamMacKey, byte cmd, int aid, int damSlotNo, byte damSlotVersion, int quotaLimit, byte key_setting_1, byte key_setting_2,
-                             byte key_setting_3, byte aks_version, byte NoKeySets, byte MaxKeySize, byte Aks, int iso_df_id, byte[] iso_df_name, byte[] enck) throws Exception {
-
+                             byte key_setting_3, byte aks_version, byte NoKeySets, byte MaxKeySize, byte Aks, Integer iso_df_id, byte[] iso_df_name, byte[] enck) {
         byte[] IV = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         byte[] input;
         int inputLength = 0;
@@ -149,20 +148,20 @@ public class DesfireDiversificationDamService implements InitializingBean {
         /* add encK at the end */
         for (byte b : enck) input[inputLength++] = b;
 
-        System.out.println("DAMMAC  in " + DesfireUtils.byteArrayToHexString(input));
-        System.out.println("DAMMAC  PICCDAMMACKey " + DesfireUtils.byteArrayToHexString(piccDamMacKey));
-        System.out.println("DAMMAC  IV " + DesfireUtils.byteArrayToHexString(IV));
+        log.info("DAMMAC  in " + DesfireUtils.byteArrayToHexString(input));
+        log.info("DAMMAC  PICCDAMMACKey " + DesfireUtils.byteArrayToHexString(piccDamMacKey));
+        log.info("DAMMAC  IV " + DesfireUtils.byteArrayToHexString(IV));
 
         byte[] CMAC_enormous = this.CalculateCMAC(piccDamMacKey, IV, input);
 
-        System.out.println("DAMMAC  out " + DesfireUtils.byteArrayToHexString(CMAC_enormous));
+        log.info("DAMMAC  out " + DesfireUtils.byteArrayToHexString(CMAC_enormous));
 
-        System.out.println("CMAC_enormous calcul soft: " + DesfireUtils.byteArrayToHexString(CMAC_enormous));
+        log.info("CMAC_enormous calcul soft: " + DesfireUtils.byteArrayToHexString(CMAC_enormous));
 
         byte[] CMAC_full = new byte[16];
         System.arraycopy(CMAC_enormous, CMAC_enormous.length - 16, CMAC_full, 0, 16);
 
-        System.out.println("CMAC_full calcul soft: " + DesfireUtils.byteArrayToHexString(CMAC_full));
+        log.info("CMAC_full calcul soft: " + DesfireUtils.byteArrayToHexString(CMAC_full));
 
         byte[] CMAC = new byte[8];
         int j = 0;
@@ -172,21 +171,26 @@ public class DesfireDiversificationDamService implements InitializingBean {
             i += 2;
         }
 
-        System.out.println("CMAC calcul soft: " + DesfireUtils.byteArrayToHexString(CMAC));
+        log.info("CMAC calcul soft: " + DesfireUtils.byteArrayToHexString(CMAC));
 
         return CMAC;
     }
 
-    public byte[] CalculateCMAC(byte[] Key, byte[] IV, byte[] input) throws Exception {
+    public byte[] CalculateCMAC(byte[] Key, byte[] IV, byte[] input) {
 
         // First : calculate subkey1 and subkey2
         byte[] Zeros = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
         //byte[] K = { 0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c } ;
 
-        byte[] L = desfireDiversification.encrypt(Key, Zeros, IV);
+        byte[] L = new byte[0];
+        try {
+            L = desfireDiversification.encrypt(Key, Zeros, IV);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 
-        System.out.println(DesfireUtils.byteArrayToHexString(L));
+        log.info(DesfireUtils.byteArrayToHexString(L));
 
         byte[] Key1;
         byte[] Key2;
@@ -215,7 +219,7 @@ public class DesfireDiversificationDamService implements InitializingBean {
 
         Key1 = L;
 
-        System.out.println(DesfireUtils.byteArrayToHexString(Key1));
+        log.info(DesfireUtils.byteArrayToHexString(Key1));
 
         byte[] tmp = new byte[Key1.length];
         System.arraycopy(Key1, 0, tmp, 0, Key1.length);
@@ -240,9 +244,9 @@ public class DesfireDiversificationDamService implements InitializingBean {
 
         Key2 = tmp;
 
-        System.out.println(DesfireUtils.byteArrayToHexString(Key2));
+        log.info(DesfireUtils.byteArrayToHexString(Key2));
 
-        byte[] result;
+        byte[] result = null;
 
         /*-------------------------------------------------*/
         /* Cas 1 : la chaine est vide    */
@@ -256,7 +260,11 @@ public class DesfireDiversificationDamService implements InitializingBean {
             for (int k = 0; k < 16; k++)
                 M1[k] = (byte) (data[k] ^ Key2[k]); // input
 
-            result = desfireDiversification.encrypt(Key, M1, IV);
+            try {
+                result = desfireDiversification.encrypt(Key, M1, IV);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
 
         } else {
             /**/
@@ -273,7 +281,11 @@ public class DesfireDiversificationDamService implements InitializingBean {
                 for (int k = 0; k < input.length; k++)
                     M1[k] = (byte) (input[k] ^ Key1[k]);
 
-                result = desfireDiversification.encrypt(Key, M1, IV);
+                try {
+                    result = desfireDiversification.encrypt(Key, M1, IV);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             } else {
                 byte[] M = new byte[input.length + 16];
                 int offset = 0;
@@ -311,7 +323,11 @@ public class DesfireDiversificationDamService implements InitializingBean {
                 byte[] Message = new byte[offset];
                 System.arraycopy(M, 0, Message, 0, offset);
 
-                result = desfireDiversification.encrypt(Key, Message, IV);
+                try {
+                    result = desfireDiversification.encrypt(Key, Message, IV);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
         return result;

--- a/src/main/java/org/esupportail/nfctag/service/desfire/actions/DesfireDamUpdateActionService.java
+++ b/src/main/java/org/esupportail/nfctag/service/desfire/actions/DesfireDamUpdateActionService.java
@@ -1,0 +1,61 @@
+package org.esupportail.nfctag.service.desfire.actions;
+
+import org.esupportail.nfctag.beans.NfcResultBean;
+import org.esupportail.nfctag.beans.NfcResultBean.Action;
+import org.esupportail.nfctag.service.TagAuthService;
+import org.esupportail.nfctag.service.api.TagIdCheckApi.TagType;
+import org.esupportail.nfctag.service.api.impl.DesfireReadConfig;
+import org.esupportail.nfctag.service.desfire.DesfireService;
+import org.esupportail.nfctag.web.live.LiveLongPoolController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DesfireDamUpdateActionService extends DesfireActionService {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    public DesfireDamUpdateActionService(DesfireReadConfig desfireReadConfig, DesfireService desfireService,
+                                      TagAuthService tagAuthService, LiveLongPoolController liveController) {
+        super(desfireReadConfig, desfireService, tagAuthService, liveController);
+    }
+
+    @Override
+    public FunctionType getFunction() {
+        return FunctionType.UPDATE;
+    }
+
+    @Override
+    NfcResultBean computeNfcResultBean(String result, String eppnInit, String cardId) {
+        NfcResultBean nfcResultBean = desfireService.damUpdateCard(result, eppnInit, cardId);
+        return nfcResultBean;
+    }
+
+    @Override
+    TagType getTagType() {
+        return TagType.CSN;
+    }
+
+    @Override
+    String getDesfireId(String result) {
+        return "";
+    }
+
+    @Override
+    String getAppName() {
+        return "";
+    }
+
+    @Override
+    NfcResultBean.Action getAction(Action action) {
+        if(updateWrite) {
+            return Action.update;
+        }
+        return action;
+    }
+
+    @Override
+    String overrideResultIfNeeded(String result) {
+        return result;
+    }
+
+}

--- a/src/main/java/org/esupportail/nfctag/web/wsrest/json/JsonFormCryptogram.java
+++ b/src/main/java/org/esupportail/nfctag/web/wsrest/json/JsonFormCryptogram.java
@@ -1,5 +1,6 @@
 package org.esupportail.nfctag.web.wsrest.json;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.esupportail.nfctag.service.desfire.DesfireUtils;
 
 public class JsonFormCryptogram {
@@ -38,8 +39,13 @@ public class JsonFormCryptogram {
         this.damDefaultKey = damDefaultKey;
     }
 
-    public byte getDamDefaultKeyVersion() {
+    @JsonIgnore
+    public byte getDamDefaultKeyVersionAsByte() {
         return DesfireUtils.hexStringToByte(damDefaultKeyVersion);
+    }
+
+    public String getDamDefaultKeyVersion() {
+        return damDefaultKeyVersion;
     }
 
     public void setDamDefaultKeyVersion(String damDefaultKeyVersion) {
@@ -62,16 +68,26 @@ public class JsonFormCryptogram {
         this.quotaLimit = quotaLimit;
     }
 
-    public byte getKeySetting1() {
+    @JsonIgnore
+    public byte getKeySetting1AsByte() {
         return DesfireUtils.hexStringToByte(keySetting1);
+    }
+
+    public String getKeySetting1() {
+        return keySetting1;
     }
 
     public void setKeySetting1(String keySetting1) {
         this.keySetting1 = keySetting1;
     }
 
-    public byte getKeySetting2() {
+    @JsonIgnore
+    public byte getKeySetting2AsByte() {
         return DesfireUtils.hexStringToByte(keySetting2);
+    }
+
+    public String getKeySetting2() {
+        return keySetting2;
     }
 
     public void setKeySetting2(String keySetting2) {
@@ -92,5 +108,20 @@ public class JsonFormCryptogram {
 
     public void setIsoDfName(String isoDfName) {
         this.isoDfName = isoDfName;
+    }
+
+    @Override
+    public String toString() {
+        return "JsonFormCryptogram{" +
+                "csn='" + csn + '\'' +
+                ", damDefaultKey='" + damDefaultKey + '\'' +
+                ", damDefaultKeyVersion='" + damDefaultKeyVersion + '\'' +
+                ", aid='" + aid + '\'' +
+                ", quotaLimit='" + quotaLimit + '\'' +
+                ", keySetting1='" + keySetting1 + '\'' +
+                ", keySetting2='" + keySetting2 + '\'' +
+                ", isoDfId='" + isoDfId + '\'' +
+                ", isoDfName='" + isoDfName + '\'' +
+                '}';
     }
 }


### PR DESCRIPTION
full implementation to write delegated application :

- In applicationContext-desfire.xml create beans with those patterns : 

```
<bean id="DamTagWriteEsupSgc" class="org.esupportail.nfctag.service.api.impl.TagWriteRestWs">
    <property name="damAuthKeyUrlTemplate" value="https://esup-nfc-tag.univ-ville.fr/wsrestdam/dam_request_auth_key?csn={0}"/>
    <property name="cryptogramUrlTemplateUrlTemplate" value="https://esup-nfc-tag.univ-ville.fr/wsrestdam/getCryptogram" />
</bean>
```
**WARNING** : damAuthKeyUrlTemplate and cryptogramUrlTemplateUrlTemplate is the ws urls of the card **owner**
```
<bean id="desfireComueTagDamUpdateEsupSgc" class="org.esupportail.nfctag.beans.DesfireTag">
	<property name="applications">
		<util:list>
			<bean class="org.esupportail.nfctag.beans.DesfireApplication" p:isoId="XXXX" p:isoName="XXXXXXXXXXXXX" p:desfireAppId="XXXXXX" p:amks="XX" p:nok="XX" p:updateDate="XXXX-XX-XX XX:XX" p:tagLastUpdateRestWs-ref="yourBean" p:tagWriteApi-ref="DamTagWriteEsupSgc">
                        </bean>
		</util:list>
	</property>
</bean>
```

```
<bean id="desfireAuthConfigComueDamUpdateEsupSgc" class="org.esupportail.nfctag.service.api.impl.DesfireDamUpdateConfig">
		<property name="desfireTag" ref="desfireComueTagDamUpdateEsupSgc" />
		<property name="description" value="Mise à jour via Dam ESUP SGC"/>
</bean>
```

- TODO : implementation of memory management in your SGC
- DEBUG : Actually isoName and isoId are required.